### PR TITLE
feat: add `fullPath` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,91 @@ pull(
 )
 ```
 
+### `fullPath`
+
+If specified the exporter will emit an entry for every path component encountered.
+
+```javascript
+const exporter = require('ipfs-unixfs-exporter')
+const pull = require('pull-stream')
+const collect = require('pull-stream/sinks/collect')
+
+pull(
+  exporter('QmFoo.../bar/baz.txt', ipld, {
+    fullPath: true
+  })
+  collect((err, files) => {
+    console.info(files)
+
+    // [{
+    //   depth: 0,
+    //   name: 'QmFoo...',
+    //   path: 'QmFoo...',
+    //   size: ...
+    //   hash: Buffer
+    //   content: undefined
+    //   type: 'dir'
+    // }, {
+    //   depth: 1,
+    //   name: 'bar',
+    //   path: 'QmFoo.../bar',
+    //   size: ...
+    //   hash: Buffer
+    //   content: undefined
+    //   type: 'dir'
+    // }, {
+    //   depth: 2,
+    //   name: 'baz.txt',
+    //   path: 'QmFoo.../bar/baz.txt',
+    //   size: ...
+    //   hash: Buffer
+    //   content: <Pull stream>
+    //   type: 'file'
+    // }]
+    //
+  })
+)
+```
+
+### `maxDepth`
+
+If specified the exporter will only emit entries up to the specified depth.
+
+```javascript
+const exporter = require('ipfs-unixfs-exporter')
+const pull = require('pull-stream')
+const collect = require('pull-stream/sinks/collect')
+
+pull(
+  exporter('QmFoo.../bar/baz.txt', ipld, {
+    fullPath: true,
+    maxDepth: 1
+  })
+  collect((err, files) => {
+    console.info(files)
+
+    // [{
+    //   depth: 0,
+    //   name: 'QmFoo...',
+    //   path: 'QmFoo...',
+    //   size: ...
+    //   hash: Buffer
+    //   content: undefined
+    //   type: 'dir'
+    // }, {
+    //   depth: 1,
+    //   name: 'bar',
+    //   path: 'QmFoo.../bar',
+    //   size: ...
+    //   hash: Buffer
+    //   content: undefined
+    //   type: 'dir'
+    // }]
+    //
+  })
+)
+```
+
 [dag API]: https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/DAG.md
 [ipld-resolver instance]: https://github.com/ipld/js-ipld-resolver
 [UnixFS]: https://github.com/ipfs/specs/tree/master/unixfs

--- a/src/dir-flat.js
+++ b/src/dir-flat.js
@@ -6,7 +6,7 @@ const cat = require('pull-cat')
 // Logic to export a unixfs directory.
 module.exports = dirExporter
 
-function dirExporter (cid, node, name, path, pathRest, resolve, size, dag, parent, depth) {
+function dirExporter (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, options) {
   const accepts = pathRest[0]
 
   const dir = {
@@ -37,7 +37,7 @@ function dirExporter (cid, node, name, path, pathRest, resolve, size, dag, paren
   ]
 
   // place dir before if not specifying subtree
-  if (!pathRest.length) {
+  if (!pathRest.length || options.fullPath) {
     streams.unshift(pull.values([dir]))
   }
 

--- a/src/dir-hamt-sharded.js
+++ b/src/dir-hamt-sharded.js
@@ -6,7 +6,7 @@ const cat = require('pull-cat')
 // Logic to export a unixfs directory.
 module.exports = shardedDirExporter
 
-function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag, parent, depth) {
+function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, options) {
   let dir
   if (!parent || (parent.path !== path)) {
     dir = {
@@ -49,7 +49,7 @@ function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag
     )
   ]
 
-  if (!pathRest.length) {
+  if (!pathRest.length || options.fullPath) {
     streams.unshift(pull.values([dir]))
   }
 

--- a/src/file.js
+++ b/src/file.js
@@ -7,7 +7,7 @@ const paramap = require('pull-paramap')
 const extractDataFromBlock = require('./extract-data-from-block')
 
 // Logic to export a single (possibly chunked) unixfs file.
-module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, offset, length) => {
+module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, options) => {
   const accepts = pathRest[0]
 
   if (accepts !== undefined && accepts !== path) {
@@ -23,6 +23,9 @@ module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, d
   }
 
   const fileSize = size || file.fileSize()
+
+  let offset = options.offset
+  let length = options.length
 
   if (offset < 0) {
     return pull.error(new Error('Offset must be greater than or equal to 0'))

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,8 @@ function pathBaseAndRest (path) {
 const defaultOptions = {
   maxDepth: Infinity,
   offset: undefined,
-  length: undefined
+  length: undefined,
+  fullPath: false
 }
 
 module.exports = (path, dag, options) => {
@@ -70,7 +71,7 @@ module.exports = (path, dag, options) => {
       return {
         depth: node.depth,
         name: node.name,
-        path: finalPathFor(node),
+        path: options.fullPath ? node.path : finalPathFor(node),
         size: node.size,
         hash: node.multihash,
         content: node.content,

--- a/src/raw.js
+++ b/src/raw.js
@@ -4,7 +4,7 @@ const pull = require('pull-stream')
 const extractDataFromBlock = require('./extract-data-from-block')
 
 // Logic to export a single raw block
-module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, offset, length) => {
+module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, options) => {
   const accepts = pathRest[0]
 
   if (accepts !== undefined && accepts !== path) {
@@ -12,6 +12,9 @@ module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, d
   }
 
   size = size || node.length
+
+  let offset = options.offset
+  let length = options.length
 
   if (offset < 0) {
     return pull.error(new Error('Offset must be greater than or equal to 0'))

--- a/test/exporter-sharded.spec.js
+++ b/test/exporter-sharded.spec.js
@@ -15,7 +15,7 @@ const randomBytes = require('./helpers/random-bytes')
 const exporter = require('../src')
 const importer = require('ipfs-unixfs-importer')
 
-const SHARD_SPLIT_THRESHOLD = 1000
+const SHARD_SPLIT_THRESHOLD = 10
 
 describe('exporter sharded', () => {
   let ipld
@@ -49,7 +49,8 @@ describe('exporter sharded', () => {
           }))
         ),
         importer(ipld, {
-          wrap: true
+          wrap: true,
+          shardSplitThreshold: SHARD_SPLIT_THRESHOLD
         }),
         pull.collect(cb)
       ),

--- a/test/exporter.spec.js
+++ b/test/exporter.spec.js
@@ -60,7 +60,7 @@ describe('exporter', () => {
     })
   }
 
-  function addTestFile ({file, strategy = 'balanced', path = '/foo', maxChunkSize, rawLeaves}, cb) {
+  function addTestFile ({ file, strategy = 'balanced', path = '/foo', maxChunkSize, rawLeaves }, cb) {
     pull(
       pull.values([{
         path,
@@ -79,8 +79,8 @@ describe('exporter', () => {
     )
   }
 
-  function addAndReadTestFile ({file, offset, length, strategy = 'balanced', path = '/foo', maxChunkSize, rawLeaves}, cb) {
-    addTestFile({file, strategy, path, maxChunkSize, rawLeaves}, (error, multihash) => {
+  function addAndReadTestFile ({ file, offset, length, strategy = 'balanced', path = '/foo', maxChunkSize, rawLeaves }, cb) {
+    addTestFile({ file, strategy, path, maxChunkSize, rawLeaves }, (error, multihash) => {
       if (error) {
         return cb(error)
       }
@@ -100,7 +100,7 @@ describe('exporter', () => {
     })
   }
 
-  function addTestDirectory ({directory, strategy = 'balanced', maxChunkSize}, callback) {
+  function addTestDirectory ({ directory, strategy = 'balanced', maxChunkSize }, callback) {
     const input = push()
     const dirName = path.basename(directory)
 
@@ -293,7 +293,8 @@ describe('exporter', () => {
         content: randomBytes(100),
         links: [
           new DAGLink('', file.node.size, file.cid)
-        ]}, cb),
+        ]
+      }, cb),
       (result, cb) => {
         pull(
           exporter(result.cid, ipld, {


### PR DESCRIPTION
When exporting a path with a subtree it's sometimes useful to get information about everything in the path and not just the node at the end.

This PR adds an option to return intermediate nodes in the export stream.

It also documents the `maxDepth` option and lowers the sharding threshold to make the shard tests more reliable in the browser.