### PR TITLE
fix: support slashes in filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chai": "^4.2.0",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
-    "ipfs-unixfs-importer": "~0.34.0",
+    "ipfs-unixfs-importer": "~0.36.0",
     "ipld": "~0.20.0",
     "ipld-dag-pb": "~0.15.0",
     "pull-pushable": "^2.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ function pathBaseAndRest (path) {
 
   return {
     base: pathBase,
-    rest: pathRest.split('/').filter(Boolean)
+    rest: toPathComponents(pathRest)
   }
 }
 
@@ -103,4 +103,12 @@ function join (paths) {
     }
     return acc + path
   }, '')
+}
+
+const toPathComponents = (path = '') => {
+  // split on / unless escaped with \
+  return (path
+    .trim()
+    .match(/([^\\\][^/]|\\\/)+/g) || [])
+    .filter(Boolean)
 }

--- a/test/exporter.spec.js
+++ b/test/exporter.spec.js
@@ -229,6 +229,34 @@ describe('exporter', () => {
     })
   })
 
+  it('small file in a directory with an escaped slash in the title', (done) => {
+    const fileName = `small-\\/file-${Math.random()}.txt`
+    const filePath = `/foo/${fileName}`
+
+    pull(
+      pull.values([{
+        path: filePath,
+        content: pull.values([smallFile])
+      }]),
+      importer(ipld),
+      pull.collect((err, files) => {
+        expect(err).to.not.exist()
+
+        const path = `/ipfs/${new CID(files[1].multihash).toBaseEncodedString()}/${fileName}`
+
+        pull(
+          exporter(path, ipld),
+          pull.collect((err, files) => {
+            expect(err).to.not.exist()
+            expect(files.length).to.equal(1)
+            expect(files[0].path).to.equal(fileName)
+            done()
+          })
+        )
+      })
+    )
+  })
+
   it('exports a chunk of a file with no links', (done) => {
     const offset = 0
     const length = 5


### PR DESCRIPTION
Someone, somewhere, will have a slash in a file name.  This upsets the importer and exporter at the moment. This PR fixes the exporter.