### PR TITLE
fix: export all files from hamt sharded directories

### DIFF
--- a/src/dir-hamt-sharded.js
+++ b/src/dir-hamt-sharded.js
@@ -33,7 +33,7 @@ function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag
         }
         if (accept) {
           return {
-            depth: depth + 1,
+            depth: p ? depth + 1 : depth,
             name: p,
             path: pp,
             multihash: link.cid.buffer,


### PR DESCRIPTION
When you pass the `maxDepth` option, if your sharded directory contains DAGLinks to other shards, you do not get the full directory contents back from the exporter. This PR fixes that.