### PR TITLE
perf: do not descend into subtrees

### DIFF
--- a/src/dir-flat.js
+++ b/src/dir-flat.js
@@ -18,9 +18,15 @@ function dirExporter (cid, node, name, path, pathRest, resolve, size, dag, paren
     type: 'dir'
   }
 
+  // we are at the max depth so no need to descend into children
+  if (options.maxDepth && options.maxDepth <= depth) {
+    return pull.values([dir])
+  }
+
   const streams = [
     pull(
       pull.values(node.links),
+      pull.filter((item) => accepts === undefined || item.name === accepts),
       pull.map((link) => ({
         depth: depth + 1,
         size: link.size,
@@ -31,7 +37,6 @@ function dirExporter (cid, node, name, path, pathRest, resolve, size, dag, paren
         pathRest: pathRest.slice(1),
         type: 'dir'
       })),
-      pull.filter((item) => accepts === undefined || item.linkName === accepts),
       resolve
     )
   ]

--- a/src/dir-hamt-sharded.js
+++ b/src/dir-hamt-sharded.js
@@ -19,6 +19,11 @@ function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag
     }
   }
 
+  // we are at the max depth so no need to descend into children
+  if (options.maxDepth && options.maxDepth <= depth) {
+    return pull.values([dir])
+  }
+
   const streams = [
     pull(
       pull.values(node.links),
@@ -31,6 +36,7 @@ function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag
         if (p && pathRest.length) {
           accept = (p === pathRest[0])
         }
+
         if (accept) {
           return {
             depth: p ? depth + 1 : depth,
@@ -49,6 +55,7 @@ function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag
     )
   ]
 
+  // place dir before if not specifying subtree
   if (!pathRest.length || options.fullPath) {
     streams.unshift(pull.values([dir]))
   }


### PR DESCRIPTION
If maxDepth is specified and we have reached that depth, do not load subtrees as we already have the requested node(s)