### PR TITLE
perf: only descend into hamt subshard that has the target entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "async": "^2.6.1",
     "cids": "~0.5.5",
     "ipfs-unixfs": "~0.1.16",
+    "ipfs-unixfs-importer": "~0.37.0",
     "pull-cat": "^1.1.11",
     "pull-paramap": "^1.2.2",
     "pull-stream": "^3.6.9",

--- a/src/dir-hamt-sharded.js
+++ b/src/dir-hamt-sharded.js
@@ -1,10 +1,15 @@
 'use strict'
 
+const defer = require('pull-defer')
 const pull = require('pull-stream/pull')
+const error = require('pull-stream/sources/error')
 const values = require('pull-stream/sources/values')
 const filter = require('pull-stream/throughs/filter')
 const map = require('pull-stream/throughs/map')
 const cat = require('pull-cat')
+const Bucket = require('hamt-sharding/src/bucket')
+const DirSharded = require('ipfs-unixfs-importer/src/importer/dir-sharded')
+const waterfall = require('async/waterfall')
 
 // Logic to export a unixfs directory.
 module.exports = shardedDirExporter
@@ -27,41 +32,180 @@ function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag
     return values([dir])
   }
 
-  const streams = [
-    pull(
-      values(node.links),
-      map((link) => {
-        // remove the link prefix (2 chars for the bucket index)
-        const p = link.name.substring(2)
-        const pp = p ? path + '/' + p : path
-        let accept = true
+  if (!pathRest.length) {
+    // return all children
 
-        if (p && pathRest.length) {
-          accept = (p === pathRest[0])
-        }
+    const streams = [
+      pull(
+        values(node.links),
+        map((link) => {
+          // remove the link prefix (2 chars for the bucket index)
+          const entryName = link.name.substring(2)
+          const entryPath = entryName ? path + '/' + entryName : path
 
-        if (accept) {
           return {
-            depth: p ? depth + 1 : depth,
-            name: p,
-            path: pp,
+            depth: entryName ? depth + 1 : depth,
+            name: entryName,
+            path: entryPath,
             multihash: link.cid.buffer,
-            pathRest: p ? pathRest.slice(1) : pathRest,
+            pathRest: entryName ? pathRest.slice(1) : pathRest,
             parent: dir || parent
           }
-        } else {
-          return ''
-        }
-      }),
-      filter(Boolean),
-      resolve
-    )
-  ]
+        }),
+        resolve
+      )
+    ]
 
-  // place dir before if not specifying subtree
-  if (!pathRest.length || options.fullPath) {
+    // place dir before if not specifying subtree
     streams.unshift(values([dir]))
+
+    return cat(streams)
   }
 
-  return cat(streams)
+  const deferred = defer.source()
+  const targetFile = pathRest[0]
+
+  // recreate our level of the HAMT so we can load only the subshard in pathRest
+  waterfall([
+    (cb) => {
+      if (!options.rootBucket) {
+        options.rootBucket = new Bucket({
+          hashFn: DirSharded.hashFn
+        })
+        options.hamtDepth = 1
+
+        return addLinksToHamtBucket(node.links, options.rootBucket, options.rootBucket, cb)
+      }
+
+      return addLinksToHamtBucket(node.links, options.lastBucket, options.rootBucket, cb)
+    },
+    (cb) => findPosition(targetFile, options.rootBucket, cb),
+    ({ position }, cb) => {
+      let prefix = toPrefix(position.pos)
+      const bucketPath = toBucketPath(position)
+
+      if (bucketPath.length > (options.hamtDepth)) {
+        options.lastBucket = bucketPath[options.hamtDepth]
+
+        prefix = toPrefix(options.lastBucket._posAtParent)
+      }
+
+      const streams = [
+        pull(
+          values(node.links),
+          map((link) => {
+            const entryPrefix = link.name.substring(0, 2)
+            const entryName = link.name.substring(2)
+            const entryPath = entryName ? path + '/' + entryName : path
+
+            if (entryPrefix !== prefix) {
+              // not the entry or subshard we're looking for
+              return false
+            }
+
+            if (entryName && entryName !== targetFile) {
+              // not the entry we're looking for
+              return false
+            }
+
+            if (!entryName) {
+              // we are doing to descend into a subshard
+              options.hamtDepth++
+            } else {
+              // we've found the node we are looking for, remove the context
+              // so we don't affect further hamt traversals
+              delete options.rootBucket
+              delete options.lastBucket
+              delete options.hamtDepth
+            }
+
+            return {
+              depth: entryName ? depth + 1 : depth,
+              name: entryName,
+              path: entryPath,
+              multihash: link.cid.buffer,
+              pathRest: entryName ? pathRest.slice(1) : pathRest,
+              parent: dir || parent
+            }
+          }),
+          filter(Boolean),
+          resolve
+        )
+      ]
+
+      if (options.fullPath) {
+        streams.unshift(values([dir]))
+      }
+
+      cb(null, streams)
+    }
+  ], (err, streams) => {
+    if (err) {
+      return deferred.resolve(error(err))
+    }
+
+    deferred.resolve(cat(streams))
+  })
+
+  return deferred
+}
+
+const addLinksToHamtBucket = (links, bucket, rootBucket, callback) => {
+  Promise.all(
+    links.map(link => {
+      if (link.name.length === 2) {
+        const pos = parseInt(link.name, 16)
+
+        return bucket._putObjectAt(pos, new Bucket({
+          hashFn: DirSharded.hashFn
+        }, bucket, pos))
+      }
+
+      return rootBucket.put(link.name.substring(2), true)
+    })
+  )
+    .catch(err => {
+      callback(err)
+      callback = null
+    })
+    .then(() => callback && callback())
+}
+
+const toPrefix = (position) => {
+  return position
+    .toString('16')
+    .toUpperCase()
+    .padStart(2, '0')
+    .substring(0, 2)
+}
+
+const findPosition = (file, bucket, cb) => {
+  bucket._findNewBucketAndPos(file)
+    .catch(err => {
+      cb(err)
+      cb = null
+    })
+    .then(position => {
+      if (!cb) {
+        // would have errored in catch block above
+        return
+      }
+
+      cb(null, { position })
+    })
+}
+
+const toBucketPath = (position) => {
+  let bucket = position.bucket
+  const path = []
+
+  while (bucket._parent) {
+    path.push(bucket)
+
+    bucket = bucket._parent
+  }
+
+  path.push(bucket)
+
+  return path.reverse()
 }

--- a/src/dir-hamt-sharded.js
+++ b/src/dir-hamt-sharded.js
@@ -80,7 +80,7 @@ function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag
       return addLinksToHamtBucket(node.links, options.lastBucket, options.rootBucket, cb)
     },
     (cb) => findPosition(targetFile, options.rootBucket, cb),
-    ({ position }, cb) => {
+    (position, cb) => {
       let prefix = toPrefix(position.pos)
       const bucketPath = toBucketPath(position)
 
@@ -191,7 +191,7 @@ const findPosition = (file, bucket, cb) => {
         return
       }
 
-      cb(null, { position })
+      cb(null, position)
     })
 }
 

--- a/test/exporter-sharded.spec.js
+++ b/test/exporter-sharded.spec.js
@@ -6,14 +6,19 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
 const UnixFS = require('ipfs-unixfs')
-const pull = require('pull-stream')
+const pull = require('pull-stream/pull')
+const values = require('pull-stream/sources/values')
+const collect = require('pull-stream/sinks/collect')
 const CID = require('cids')
 const waterfall = require('async/waterfall')
 const parallel = require('async/parallel')
 const randomBytes = require('./helpers/random-bytes')
-
 const exporter = require('../src')
 const importer = require('ipfs-unixfs-importer')
+const {
+  DAGLink,
+  DAGNode
+} = require('ipld-dag-pb')
 
 const SHARD_SPLIT_THRESHOLD = 10
 
@@ -21,6 +26,32 @@ describe('exporter sharded', function () {
   this.timeout(30000)
 
   let ipld
+
+  const createShard = (numFiles, callback) => {
+    createShardWithFileNames(numFiles, (index) => `file-${index}`, callback)
+  }
+
+  const createShardWithFileNames = (numFiles, fileName, callback) => {
+    const files = new Array(numFiles).fill(0).map((_, index) => ({
+      path: fileName(index),
+      content: Buffer.from([0, 1, 2, 3, 4, index])
+    }))
+
+    createShardWithFiles(files, callback)
+  }
+
+  const createShardWithFiles = (files, callback) => {
+    pull(
+      values(files),
+      importer(ipld, {
+        shardSplitThreshold: SHARD_SPLIT_THRESHOLD,
+        wrap: true
+      }),
+      collect((err, files) => {
+        callback(err, files ? new CID(files.pop().multihash) : undefined)
+      })
+    )
+  }
 
   before((done) => {
     IPLD.inMemory((err, resolver) => {
@@ -126,7 +157,8 @@ describe('exporter sharded', function () {
           }))
         ),
         importer(ipld, {
-          wrap: true
+          wrap: true,
+          shardSplitThreshold: SHARD_SPLIT_THRESHOLD
         }),
         pull.collect(cb)
       ),
@@ -147,6 +179,269 @@ describe('exporter sharded', function () {
         expect(exported.length).to.equal(Object.keys(files).length)
 
         cb()
+      }
+    ], done)
+  })
+
+  it('exports all files from a sharded directory with subshards', (done) => {
+    waterfall([
+      (cb) => createShard(31, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}`, ipld),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(32)
+
+          const dir = exported.shift()
+
+          expect(dir.type).to.equal('dir')
+
+          exported.forEach(file => expect(file.type).to.equal('file'))
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('exports one file from a sharded directory', (done) => {
+    waterfall([
+      (cb) => createShard(31, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/file-14`, ipld),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(1)
+
+          const file = exported.shift()
+
+          expect(file.name).to.deep.equal('file-14')
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('exports one file from a sharded directory sub shard', (done) => {
+    waterfall([
+      (cb) => createShard(31, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/file-30`, ipld),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(1)
+
+          const file = exported.shift()
+
+          expect(file.name).to.deep.equal('file-30')
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('exports one file from a shard inside a shard inside a shard', (done) => {
+    waterfall([
+      (cb) => createShard(2568, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/file-2567`, ipld),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(1)
+
+          const file = exported.shift()
+
+          expect(file.name).to.deep.equal('file-2567')
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('uses maxDepth to only extract a deep folder from the sharded directory', (done) => {
+    waterfall([
+      (cb) => createShardWithFileNames(31, (index) => `/foo/bar/baz/file-${index}`, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz`, ipld, {
+            maxDepth: 3
+          }),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(1)
+
+          const entry = exported.pop()
+
+          expect(entry.name).to.deep.equal('baz')
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('uses maxDepth to only extract an intermediate folder from the sharded directory', (done) => {
+    waterfall([
+      (cb) => createShardWithFileNames(31, (index) => `/foo/bar/baz/file-${index}`, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz`, ipld, {
+            maxDepth: 2
+          }),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(1)
+
+          const entry = exported.pop()
+
+          expect(entry.name).to.deep.equal('bar')
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('uses fullPath extract all intermediate entries from the sharded directory', (done) => {
+    waterfall([
+      (cb) => createShardWithFileNames(31, (index) => `/foo/bar/baz/file-${index}`, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz/file-1`, ipld, {
+            fullPath: true
+          }),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(5)
+
+          expect(exported[1].name).to.equal('foo')
+          expect(exported[2].name).to.equal('bar')
+          expect(exported[3].name).to.equal('baz')
+          expect(exported[4].name).to.equal('file-1')
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('uses fullPath extract all intermediate entries from the sharded directory as well as the contents', (done) => {
+    waterfall([
+      (cb) => createShardWithFileNames(31, (index) => `/foo/bar/baz/file-${index}`, cb),
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz`, ipld, {
+            fullPath: true
+          }),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(35)
+
+          expect(exported[1].name).to.equal('foo')
+          expect(exported[2].name).to.equal('bar')
+          expect(exported[3].name).to.equal('baz')
+          expect(exported[4].name).to.equal('file-14')
+
+          exported.slice(4).forEach(file => expect(file.type).to.equal('file'))
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], done)
+  })
+
+  it('exports a file from a sharded directory inside a regular directory inside a sharded directory', (done) => {
+    waterfall([
+      (cb) => createShard(15, cb),
+      (dir, cb) => {
+        DAGNode.create(new UnixFS('directory').marshal(), [
+          new DAGLink('shard', 5, dir)
+        ], cb)
+      },
+      (node, cb) => {
+        ipld.put(node, {
+          version: 0,
+          format: 'dag-pb',
+          hashAlg: 'sha2-256'
+        }, cb)
+      },
+      (cid, cb) => {
+        DAGNode.create(new UnixFS('hamt-sharded-directory').marshal(), [
+          new DAGLink('75normal-dir', 5, cid)
+        ], cb)
+      },
+      (node, cb) => {
+        ipld.put(node, {
+          version: 1,
+          format: 'dag-pb',
+          hashAlg: 'sha2-256'
+        }, cb)
+      },
+      (dir, cb) => {
+        pull(
+          exporter(`/ipfs/${dir.toBaseEncodedString()}/normal-dir/shard/file-1`, ipld),
+          pull.collect(cb)
+        )
+      },
+      (exported, cb) => {
+        try {
+          expect(exported.length).to.equal(1)
+
+          const entry = exported.pop()
+
+          expect(entry.name).to.deep.equal('file-1')
+
+          cb()
+        } catch (e) {
+          cb(e)
+        }
       }
     ], done)
   })

--- a/test/exporter-sharded.spec.js
+++ b/test/exporter-sharded.spec.js
@@ -85,7 +85,7 @@ describe('exporter sharded', function () {
           wrap: true,
           shardSplitThreshold: SHARD_SPLIT_THRESHOLD
         }),
-        pull.collect(cb)
+        collect(cb)
       ),
       (imported, cb) => {
         directory = new CID(imported.pop().multihash)
@@ -104,7 +104,7 @@ describe('exporter sharded', function () {
 
         pull(
           exporter(directory, ipld),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
@@ -117,7 +117,7 @@ describe('exporter sharded', function () {
           exported.map(exported => (cb) => {
             pull(
               exported.content,
-              pull.collect((err, bufs) => {
+              collect((err, bufs) => {
                 if (err) {
                   cb(err)
                 }
@@ -160,7 +160,7 @@ describe('exporter sharded', function () {
           wrap: true,
           shardSplitThreshold: SHARD_SPLIT_THRESHOLD
         }),
-        pull.collect(cb)
+        collect(cb)
       ),
       (imported, cb) => {
         dirCid = new CID(imported.pop().multihash)
@@ -169,7 +169,7 @@ describe('exporter sharded', function () {
           exporter(dirCid, ipld, {
             maxDepth: 1
           }),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
@@ -189,23 +189,19 @@ describe('exporter sharded', function () {
       (dir, cb) => {
         pull(
           exporter(`/ipfs/${dir.toBaseEncodedString()}`, ipld),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(32)
+        expect(exported.length).to.equal(32)
 
-          const dir = exported.shift()
+        const dir = exported.shift()
 
-          expect(dir.type).to.equal('dir')
+        expect(dir.type).to.equal('dir')
 
-          exported.forEach(file => expect(file.type).to.equal('file'))
+        exported.forEach(file => expect(file.type).to.equal('file'))
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -216,21 +212,17 @@ describe('exporter sharded', function () {
       (dir, cb) => {
         pull(
           exporter(`/ipfs/${dir.toBaseEncodedString()}/file-14`, ipld),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(1)
+        expect(exported.length).to.equal(1)
 
-          const file = exported.shift()
+        const file = exported.shift()
 
-          expect(file.name).to.deep.equal('file-14')
+        expect(file.name).to.deep.equal('file-14')
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -241,21 +233,17 @@ describe('exporter sharded', function () {
       (dir, cb) => {
         pull(
           exporter(`/ipfs/${dir.toBaseEncodedString()}/file-30`, ipld),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(1)
+        expect(exported.length).to.equal(1)
 
-          const file = exported.shift()
+        const file = exported.shift()
 
-          expect(file.name).to.deep.equal('file-30')
+        expect(file.name).to.deep.equal('file-30')
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -266,21 +254,17 @@ describe('exporter sharded', function () {
       (dir, cb) => {
         pull(
           exporter(`/ipfs/${dir.toBaseEncodedString()}/file-2567`, ipld),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(1)
+        expect(exported.length).to.equal(1)
 
-          const file = exported.shift()
+        const file = exported.shift()
 
-          expect(file.name).to.deep.equal('file-2567')
+        expect(file.name).to.deep.equal('file-2567')
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -293,21 +277,17 @@ describe('exporter sharded', function () {
           exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz`, ipld, {
             maxDepth: 3
           }),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(1)
+        expect(exported.length).to.equal(1)
 
-          const entry = exported.pop()
+        const entry = exported.pop()
 
-          expect(entry.name).to.deep.equal('baz')
+        expect(entry.name).to.deep.equal('baz')
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -320,21 +300,17 @@ describe('exporter sharded', function () {
           exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz`, ipld, {
             maxDepth: 2
           }),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(1)
+        expect(exported.length).to.equal(1)
 
-          const entry = exported.pop()
+        const entry = exported.pop()
 
-          expect(entry.name).to.deep.equal('bar')
+        expect(entry.name).to.deep.equal('bar')
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -347,22 +323,18 @@ describe('exporter sharded', function () {
           exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz/file-1`, ipld, {
             fullPath: true
           }),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(5)
+        expect(exported.length).to.equal(5)
 
-          expect(exported[1].name).to.equal('foo')
-          expect(exported[2].name).to.equal('bar')
-          expect(exported[3].name).to.equal('baz')
-          expect(exported[4].name).to.equal('file-1')
+        expect(exported[1].name).to.equal('foo')
+        expect(exported[2].name).to.equal('bar')
+        expect(exported[3].name).to.equal('baz')
+        expect(exported[4].name).to.equal('file-1')
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -375,24 +347,20 @@ describe('exporter sharded', function () {
           exporter(`/ipfs/${dir.toBaseEncodedString()}/foo/bar/baz`, ipld, {
             fullPath: true
           }),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(35)
+        expect(exported.length).to.equal(35)
 
-          expect(exported[1].name).to.equal('foo')
-          expect(exported[2].name).to.equal('bar')
-          expect(exported[3].name).to.equal('baz')
-          expect(exported[4].name).to.equal('file-14')
+        expect(exported[1].name).to.equal('foo')
+        expect(exported[2].name).to.equal('bar')
+        expect(exported[3].name).to.equal('baz')
+        expect(exported[4].name).to.equal('file-14')
 
-          exported.slice(4).forEach(file => expect(file.type).to.equal('file'))
+        exported.slice(4).forEach(file => expect(file.type).to.equal('file'))
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })
@@ -427,21 +395,17 @@ describe('exporter sharded', function () {
       (dir, cb) => {
         pull(
           exporter(`/ipfs/${dir.toBaseEncodedString()}/normal-dir/shard/file-1`, ipld),
-          pull.collect(cb)
+          collect(cb)
         )
       },
       (exported, cb) => {
-        try {
-          expect(exported.length).to.equal(1)
+        expect(exported.length).to.equal(1)
 
-          const entry = exported.pop()
+        const entry = exported.pop()
 
-          expect(entry.name).to.deep.equal('file-1')
+        expect(entry.name).to.deep.equal('file-1')
 
-          cb()
-        } catch (e) {
-          cb(e)
-        }
+        cb()
       }
     ], done)
   })


### PR DESCRIPTION
Since bucket indexes are stable based on the file input and current tree state, we can predict which subshard will contain a given file based on how deep we are in the hamt, so there's no need to traverse the entire shard to find one file.

Fixes #9