### PR TITLE
refactor: exported file links

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -150,25 +150,21 @@ function getChildren (dag, offset, end) {
 
     return pull(
       once(filteredLinks),
-      paramap((children, cb) => {
-        dag.getMany(children.map(child => child.link.cid), (err, results) => {
+      flatten(),
+      paramap((child, cb) => {
+        dag.get(child.link.cid, '', (err, res) => {
           if (err) {
             return cb(err)
           }
 
-          cb(null, results.map((result, index) => {
-            const child = children[index]
-
-            return {
-              start: child.start,
-              end: child.end,
-              node: result,
-              size: child.size
-            }
-          }))
+          cb(null, {
+            start: child.start,
+            end: child.end,
+            node: res.value,
+            size: child.size
+          })
         })
-      }),
-      flatten()
+      })
     )
   }
 }


### PR DESCRIPTION
Previously we used `getMany` to get **ALL** of the links for a particular file node before passing them on to the next step in the pipeline.

This PR refactors that to get the blocks _individually in parallel_, allowing them to be passed on to the next stage in the pipeline as they arrive.

I don't know if this is faster than the previous method. In fact, I can see how it might be slower. However, it does mean that we don't have to wait for **ALL** linked blocks to arrive before they are passed to the next stage in the pipeline and by doing this it will reduce the time to first byte when using `ipfs.cat*Stream` which is good from a UX perspective.

A streaming `getMany` from IPLD would actually be useful here, which could be pushed down to bitswap so that it can make good decisions about what network requests to make.

cc  @vmx