### PR TITLE
refactor: use ipld-in-memory module

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dirty-chai": "^2.0.1",
     "ipld": "~0.20.2",
     "ipld-dag-pb": "~0.15.2",
+    "ipld-in-memory": "^2.0.0",
     "pull-pushable": "^2.2.0",
     "pull-stream-to-stream": "^1.3.4",
     "pull-zip": "^2.0.1",

--- a/test/exporter-sharded.spec.js
+++ b/test/exporter-sharded.spec.js
@@ -5,6 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const UnixFS = require('ipfs-unixfs')
 const pull = require('pull-stream/pull')
 const values = require('pull-stream/sources/values')
@@ -54,7 +55,7 @@ describe('exporter sharded', function () {
   }
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/exporter-subtree.spec.js
+++ b/test/exporter-subtree.spec.js
@@ -5,6 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const CID = require('cids')
 const pull = require('pull-stream')
 const randomBytes = require('./helpers/random-bytes')
@@ -19,7 +20,7 @@ describe('exporter subtree', () => {
   let ipld
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver

--- a/test/exporter.spec.js
+++ b/test/exporter.spec.js
@@ -5,6 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const IPLD = require('ipld')
+const inMemory = require('ipld-in-memory')
 const UnixFS = require('ipfs-unixfs')
 const pull = require('pull-stream')
 const zip = require('pull-zip')
@@ -171,7 +172,7 @@ describe('exporter', () => {
   }
 
   before((done) => {
-    IPLD.inMemory((err, resolver) => {
+    inMemory(IPLD, (err, resolver) => {
       expect(err).to.not.exist()
 
       ipld = resolver


### PR DESCRIPTION
The `inMemory` util is going away to remove dependence on IPFS. This PR switches to using the `ipld-in-memory` module which does the same thing.