### PR TITLE
chore: update importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "err-code": "^1.1.2",
     "hamt-sharding": "~0.0.2",
     "ipfs-unixfs": "~0.1.16",
-    "ipfs-unixfs-importer": "~0.38.5"
+    "ipfs-unixfs-importer": "~0.39.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",


### PR DESCRIPTION
The importer & exporter use each other in their tests.  The async/await conversion broke the public API quite badly so had to publish an importer on a broken build in order fix the build of the exporter.  Once that is green & published the importer will get the new exporter which will fix the importer build.

Hooray.